### PR TITLE
Enhance text: fix typos, add English terms, and improve punctuation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1858,7 +1858,7 @@
             title="[신규]">초점 표시기(focus indicator)</a>가 보이는 경우, 이 영역은 다음 모든 조건을 충족해야 한다:
         </p>
         <ul>
-          <li>초점을 받지 않은 구성 요소 또는 하위 구성요소의 <a href="#dfn-perimeter" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-perimeter-1" title="[신규]">외곽</a> 두께를 2 <a href="#dfn-css-pixels" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-css-pixels-3" title="약 0.0213도의 시야각">CSS 픽셀</a> 이상으로 설정헤애 한다.</li>
+          <li>초점을 받지 않은 구성 요소 또는 하위 구성요소의 <a href="#dfn-perimeter" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-perimeter-1" title="[신규]">외곽</a> 두께를 2 <a href="#dfn-css-pixels" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-css-pixels-3" title="약 0.0213도의 시야각">CSS 픽셀</a> 이상으로 설정해야 한다.</li>
           <li>초점을 받은 상태와 받지 않은 상태의 동일한 픽셀 간 명도대비율이 최소 3:1 이상이어야 한다.</li>
         </ul>
         <p>예외:</p>

--- a/index.html
+++ b/index.html
@@ -3920,7 +3920,7 @@
           사용자가 인식할 수 있는 형태로 <a href="#dfn-content" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-content-4" title="콘텐츠의 구조, 표현 및 상호 작용을 정의하는 코드나 마크업을 포함하여 사용자 에이전트를 통해 사용자에게 전달되는 정보 및 감각 경험">콘텐츠</a>를 렌더링하는 것
         </p>
       </dd>
-      <dt><dfn data-lt="primary education|primary education level" id="dfn-primary-education" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">초등 교육 level</dfn></dt>
+      <dt><dfn data-lt="primary education|primary education level" id="dfn-primary-education" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">초등 교육 수준(primary education level)</dfn></dt>
       <dd>
         <p>사전 교육이 없을 수 있는, 5~7세 사이에 시작된 6년 간의 교육 기간</p>
         <div class="note" role="note" id="issue-container-generatedID-132">

--- a/index.html
+++ b/index.html
@@ -2515,7 +2515,7 @@
         <p class="conformance-level">(Level AA)</p>
         <p class="change">[신규]</p>
         <p>
-          다음 중 하나 이상을 제공하지 않는 한 인증 <a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-3" title="활동을 완료하기 위해 각 작업이 필요한 일련의 사용자 작업">과정</a>의 어떤 단계에서도 <a href="#dfn-cognitive-function-test" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-cognitive-function-test-1" title="[신규]">인지 기능 검사</a>(예: 비밀번호 기억 또는 퍼즐 풀기)를 요구할 수 없다.
+          다음 중 하나 이상을 제공하지 않는 한, 인증 <a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-3" title="활동을 완료하기 위해 각 작업이 필요한 일련의 사용자 작업">과정</a>의 어떤 단계에서도 <a href="#dfn-cognitive-function-test" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-cognitive-function-test-1" title="[신규]">인지 기능 검사</a>(예: 비밀번호 기억 또는 퍼즐 풀기)를 요구할 수 없다.
         </p>
         <dl>
           <dt>대체 수단</dt>
@@ -2553,7 +2553,7 @@
         <p class="conformance-level">(Level AAA)</p>
         <p class="change">[신규]</p>
         <p>
-          다음 중 하나 이상을 제공하지 않는 한 인증 <a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-3" title="활동을 완료하기 위해 각 작업이 필요한 일련의 사용자 작업">과정</a>의 어떤 단계에서도 <a href="#dfn-cognitive-function-test" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-cognitive-function-test-1" title="[신규]">인지 기능 검사</a>(예: 비밀번호 기억 또는 퍼즐 풀기)를 요구할 수 없다.
+          다음 중 하나 이상을 제공하지 않는 한, 인증 <a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-3" title="활동을 완료하기 위해 각 작업이 필요한 일련의 사용자 작업">과정</a>의 어떤 단계에서도 <a href="#dfn-cognitive-function-test" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-cognitive-function-test-1" title="[신규]">인지 기능 검사</a>(예: 비밀번호 기억 또는 퍼즐 풀기)를 요구할 수 없다.
         </p>
         <dl>
           <dt>대체 수단</dt>
@@ -3062,7 +3062,7 @@
         <div class="note" role="note" id="issue-container-generatedID-63">
           <div role="heading" class="note-title marker" id="h-note-63" aria-level="3"><span>참고 5</span></div>
           <p>
-            개발자가 접근성이 지원되는 기술의 사용을 찾는 한 가지 방법은 접근성이 지원되는 것으로 문서화된 사용 책자를 참고하는 것이다. (<a href="https://www.w3.org/WAI/WCAG21/Understanding/conformance#documented-lists">접근성이 지원되는 웹 기술 활용 이해</a>를 참고하라.) 웹 콘텐츠 저작자, 회사, 기술공급업체 또는 기타 업체가 웹 콘텐츠 기술을 사용하는 접근성이 지원되는 방법을 문서화할 수 있다. 그러나 문서에서 기술을 사용하는 모든 방법은 위의 접근성이 지원되는 웹 콘텐츠 기술의 정의를 충족해야 한다.
+            개발자가 접근성이 지원되는 기술의 사용을 찾는 한, 가지 방법은 접근성이 지원되는 것으로 문서화된 사용 책자를 참고하는 것이다. (<a href="https://www.w3.org/WAI/WCAG21/Understanding/conformance#documented-lists">접근성이 지원되는 웹 기술 활용 이해</a>를 참고하라.) 웹 콘텐츠 저작자, 회사, 기술공급업체 또는 기타 업체가 웹 콘텐츠 기술을 사용하는 접근성이 지원되는 방법을 문서화할 수 있다. 그러나 문서에서 기술을 사용하는 모든 방법은 위의 접근성이 지원되는 웹 콘텐츠 기술의 정의를 충족해야 한다.
           </p>
         </div>
       </dd>

--- a/index.html
+++ b/index.html
@@ -4005,7 +4005,7 @@
           </p>
         </aside>
       </dd>
-      <dt><dfn data-lt="real-time events|real-time event" id="dfn-real-time-events" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">실시간 이벤트</dfn></dt>
+      <dt><dfn data-lt="real-time events|real-time event" id="dfn-real-time-events" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">실시간 이벤트(real-time event)</dfn></dt>
       <dd>
         <p>
           a) 보기와 동시에 발생하고, b) 완전히 콘텐츠에 의해 생성되지 않는 이벤트

--- a/index.html
+++ b/index.html
@@ -466,7 +466,7 @@
       </p>
       <ul>
         <li>
-          <p><strong>원칙(Principles)</strong> - 최상위에는 웹 접근성의 기초를 제공하는 4가지 원칙, 즉 <em>인식의 용이성(perceivable), 운용의 용이성(operable), 이해의 용이성(understandable), 그리고 견고성(robust)</em>이 있다. <a href="https://www.w3.org/WAI/WCAG22/Understanding/intro#understanding-the-four-principles-of-accessibility">네 가지 접근성 원칙 이해</a>[네 가지 접근성 원칙 이해](https://www.w3.org/WAI/WCAG21/Understanding/intro#understanding-the-four-principles-of-accessibility)를 참고하라.
+          <p><strong>원칙(Principles)</strong> - 최상위에는 웹 접근성의 기초를 제공하는 4가지 원칙, 즉 <em>인식의 용이성(perceivable), 운용의 용이성(operable), 이해의 용이성(understandable), 그리고 견고성(robust)</em>이 있다. <a href="https://www.w3.org/WAI/WCAG22/Understanding/intro#understanding-the-four-principles-of-accessibility">네 가지 접근성 원칙 이해</a>를 참고하라.
           </p>
         </li>
         <li>

--- a/index.html
+++ b/index.html
@@ -2342,7 +2342,7 @@
         <p class="conformance-level">(Level A)</p>
         <p class="change">[신규]</p>
         <p>
-          <a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-9" title="HTTP를 사용하여 단일 URI에서 얻어진 내장 안 된 리소스(non-embedded resource)과 렌더링에 사용되거나 사용자 에이전트에서 렌더링되도록 의도된 모든 다른 리소스">웹 페이지</a>에 다음 도움말 <a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-mechanism-12" title="결과에 도달하기 위한 과정이나 기법">매커니즘</a> 중 하나가 포함되어 있고 해당 매커니즘이 <a href="#dfn-set-of-web-pages" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-set-of-web-pages-5" title="동일한 개발자, 그룹 또는 조직에 의해 작성되고 공통의 목적을 공유하는 웹 페이지의 모음">웹 페이지 세트</a> 내의 여러 웹 페이지에서 반복되는 경우 사용자가 변경을 시작하지 않는 한 다른 페이지 콘텐츠와 상대적으로 동일한 순서로 제공되어야 한다.
+          <a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-9" title="HTTP를 사용하여 단일 URI에서 얻어진 내장 안 된 리소스(non-embedded resource)과 렌더링에 사용되거나 사용자 에이전트에서 렌더링되도록 의도된 모든 다른 리소스">웹 페이지</a>에 다음 도움말 <a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-mechanism-12" title="결과에 도달하기 위한 과정이나 기법">매커니즘</a> 중 하나가 포함되어 있고, 해당 매커니즘이 <a href="#dfn-set-of-web-pages" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-set-of-web-pages-5" title="동일한 개발자, 그룹 또는 조직에 의해 작성되고 공통의 목적을 공유하는 웹 페이지의 모음">웹 페이지 세트</a> 내의 여러 웹 페이지에서 반복되는 경우, 사용자가 변경을 시작하지 않는 한 다른 페이지 콘텐츠와 상대적으로 동일한 순서로 제공되어야 한다.
         </p>
         <ul>
           <li>사람의 연락처 정보</li>


### PR DESCRIPTION
This pull request includes several improvements to the text:
- Fixed typos throughout the document
- Added missing English terms in parentheses for consistency
- Improved readability by adding commas
    - Omitted structural commas(문장 구조의 쉼표) in sentences that already contain listing commas(열거의 쉼표) to avoid complexity